### PR TITLE
Moved "Fork me on GitHub" button to the right side

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -122,7 +122,7 @@
 
     <div class="container">
     <a href="https://github.com/sholiday/Unofficial-Waterloo-USA-Intern-Guide">
-      <img style="position: absolute; top: 40px; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_green_007200.png" alt="Fork me on GitHub">
+      <img style="position: absolute; top: 40px; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
     </a>
     {{ content }}
       <footer>


### PR DESCRIPTION
Just fixing a minor annoyance, it was blocking the title.

Screenshot of the fix:
![screenshot 2015-04-22 18 12 28](https://cloud.githubusercontent.com/assets/2029031/7286615/4c288cb4-e91b-11e4-970b-7debf11f05fb.png)
